### PR TITLE
Revert `assert_contain` and `assert_not_contain`

### DIFF
--- a/lib/webrat/core/matchers/have_content.rb
+++ b/lib/webrat/core/matchers/have_content.rb
@@ -54,14 +54,14 @@ module Webrat
     # the supplied string or regexp
     def assert_contain(content)
       hc = HasContent.new(content)
-      assert hc.matches?(current_dom), hc.failure_message
+      assert hc.matches?(response_body), hc.failure_message
     end
 
     # Asserts that the body of the response
     # does not contain the supplied string or regepx
     def assert_not_contain(content)
       hc = HasContent.new(content)
-      assert !hc.matches?(current_dom), hc.negative_failure_message
+      assert !hc.matches?(response_body), hc.negative_failure_message
     end
 
   end


### PR DESCRIPTION
Looks like the changes from the latest version of the original gem are
making the features fail.
- Replace `current_dom` with `response_body`
